### PR TITLE
Fixed readme for recent ev3dev buildscripts and changed the default…

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,7 @@ First time kernel build
     [Faster Builds and Custom Locations](#faster-builds-and-custom-locations)
     section below for more about this file.
 
-        ~/work/ev3dev-buildscripts $ echo "#\!/bin/sh
-        
-        export EV3DEV_MAKE_ARGS=-j4" > local-env
+        ~/work/ev3dev-buildscripts $ echo "export EV3DEV_MAKE_ARGS=-j4" > local-env
 
 7.  Now we can compile the kernel.
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ First time kernel build
 
         ~/work $ git clone git://github.com/ev3dev/ev3dev-buildscripts
         ~/work $ git clone --recursive git://github.com/ev3dev/ev3-kernel
-        ~/work $ cd drivers/lego
-        ~/work/drivers/lego $ git pull
-        ~/work/drivers/lego $ cd ../..
+        ~/work $ cd ev3-kernel/drivers/lego
+        ~/work/ev3-kernel/drivers/lego $ git pull origin master
+        ~/work/ev3-kernel/drivers/lego $ cd ../../..
 
 4.  Change to the `ev3dev-buildscripts` directory and have a look around.
 
@@ -68,31 +68,31 @@ First time kernel build
     ev3dev package repo and then run the `install-kernel-build-tools` script.
     (You only need to run this once.)
 
-        ~/work/ev3dev-buildscripts $ .sudo apt-add-repository http://ev3dev.org/debian
-        ~/work/ev3dev-buildscripts $ .sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 2B210565
-        ~/work/ev3dev-buildscripts $ .sudo apt-get update
+        ~/work/ev3dev-buildscripts $ sudo apt-add-repository http://ev3dev.org/debian
+        ~/work/ev3dev-buildscripts $ sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 2B210565
+        ~/work/ev3dev-buildscripts $ sudo apt-get update
         ~/work/ev3dev-buildscripts $ ./install-kernel-build-tools
 
 6.  Create a `local-env` to make use of all of your processing power. See the
     [Faster Builds and Custom Locations](#faster-builds-and-custom-locations)
     section below for more about this file.
 
-        ~/work/ev3dev-buildscripts $ echo "#!/bin/sh
+        ~/work/ev3dev-buildscripts $ echo "#\!/bin/sh
         
         export EV3DEV_MAKE_ARGS=-j4" > local-env
 
 7.  Now we can compile the kernel.
 
-        ~/work/ev3dev-buildscripts $ ./build_kernel
+        ~/work/ev3dev-buildscripts $ ./build-kernel
 
 8.  That's it! The uImage and kernel modules you just built are saved in
     `../dist`. You just need to copy the files to your
     already formatted SD card. For an easier way of getting the kernel on
     your EV3, see [Sharing Your Kernel](#sharing-your-kernel).
 
-        ~/work/ev3dev-buildscripts $ cd ../dist
-        ~/work/dist $ cp uImage <path-to-boot-partition>/uImage
-        ~/work/dist $ sudo cp -r lib/ <path-to-file-system-partition>
+        ~/work/ev3dev-buildscripts $ cd ./build-area/linux-ev3dev-ev3-dist
+        ~/work/ev3dev-buildscripts/build-area/linux-ev3dev-ev3-dist $ cp uImage <path-to-boot-partition>/uImage
+        ~/work/ev3dev-buildscripts/build-area/linux-ev3dev-ev3-dist $ sudo cp -r lib/ <path-to-file-system-partition>
 
 
 Faster Builds and Custom Locations

--- a/setup-env
+++ b/setup-env
@@ -27,7 +27,7 @@ export EV3DEV_TOOLCHAIN="/opt/arm-2011.03/bin"
 export EV3DEV_ABI="arm-none-eabi-"
 
 # This is where the scripts put all of generated files
-export EV3DEV_BUILD_AREA="$HOME/build-area"
+export EV3DEV_BUILD_AREA="$(pwd)/build-area"
 
 # This is where the ev3dev linux kernel git repository is checked out
 export EV3DEV_KERNEL="$(pwd)/../ev3-kernel"


### PR DESCRIPTION
…folder of build-area to stay in the ev3dev-buildscripts folder and not in $HOME.

For me it does only work with the made changes.
