### PR TITLE
ev3dev-trixie

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,10 @@ System Requirements
 * User account with `sudo` enabled
 * Packages:
 
-        # If you haven't already added the ev3dev.org repository...
-        sudo apt-add-repository ppa:ev3dev/tools
         sudo apt-get update
         # then install required packages
         sudo apt-get install git build-essential ncurses-dev fakeroot bc \
-        u-boot-tools lzop flex bison libssl-dev \
-        gcc-linaro-arm-linux-gnueabihf-6.4
+        u-boot-tools lzop flex bison libssl-dev gcc-arm-linux-gnueabi
 
 
 Scripts
@@ -53,11 +50,9 @@ First time kernel build
     update the submodule commit in the kernel repo, so you have to pull manually
     to get the most recent commits).
 
-        ~/work $ git clone git://github.com/ev3dev/ev3dev-buildscripts
-        ~/work $ git clone --recursive --depth 150 git://github.com/ev3dev/ev3-kernel
-        ~/work $ cd ev3-kernel/drivers/lego
-        ~/work/ev3-kernel/drivers/lego $ git pull origin ev3dev-stretch
-        ~/work/ev3-kernel/drivers/lego $ cd -
+        ~/work $ git clone https://github.com/ev3dev/ev3dev-buildscripts --branch ev3dev-stretch
+        ~/work $ git clone --recursive --depth 150 https://github.com/ev3dev/ev3-kernel \
+        --branch ev3dev-stretch
 
 3.  Change to the `ev3dev-buildscripts` directory and have a look around.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ System Requirements
         sudo apt-get update
         # then install required packages
         sudo apt-get install git build-essential ncurses-dev fakeroot bc \
-        u-boot-tools lzop flex bison libssl-dev gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf
+        u-boot-tools lzop flex bison libssl-dev gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf -y
 
 
 Scripts

--- a/README.md
+++ b/README.md
@@ -79,14 +79,19 @@ First time kernel build
         # BeagleBoard
         EV3DEV_KERNEL_FLAVOR=bb.org ./build-kernel
 
-6.  That's it!  
+6.  That's it! The uImage and kernel modules you just built are saved in
+    `./build-area`. You just need to copy the files to your
+    already formatted SD card. For an easier way of getting the kernel on
+    your EV3, see [Sharing Your Kernel](#sharing-your-kernel). Starting with
+    ev3dev-stretch images dated 2018-05 or later, the uImage file is no longer
+    used. Create a Debian package as described in the *Sharing Your Kernel*
+    section.
 
-    TODO: add instructions on how to modify uEnv.txt to use uImage file.
- 
-    For now, see [Sharing Your Kernel](#sharing-your-kernel) for how to create
-    a debian package to install the kernel you just built.
+        ~/work/ev3dev-buildscripts $ cd ./build-area/linux-ev3dev-ev3-dist
+        ~/work/ev3dev-buildscripts/build-area/linux-ev3dev-ev3-dist $ cp uImage <path-to-boot-partition>/uImage
+        ~/work/ev3dev-buildscripts/build-area/linux-ev3dev-ev3-dist $ sudo cp -r lib/ <path-to-file-system-partition>
 
-
+    
 Faster Builds and Custom Locations
 ----------------------------------
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,8 @@ First time kernel build
     update the submodule commit in the kernel repo, so you have to pull manually
     to get the most recent commits).
 
-        ~/work $ git clone https://github.com/ev3dev/ev3dev-buildscripts --branch ev3dev-stretch
-        ~/work $ git clone --recursive --depth 150 https://github.com/ev3dev/ev3-kernel \
-        --branch ev3dev-stretch
+        ~/work $ git clone https://github.com/project516/ev3dev-buildscripts
+        ~/work $ git clone --recursive --depth 25 https://github.com/project516/ev3-kernel
 
 3.  Change to the `ev3dev-buildscripts` directory and have a look around.
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,5 @@ Rebasing
 ```bash
 git remote add kernel https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
 git fetch kernel tag v6.12.y
-git checkout bookworm
 git rebase v6.12.y
 ```

--- a/README.md
+++ b/README.md
@@ -226,3 +226,13 @@ Common Errors
 
 [brickstrap]: https://github.com/ev3dev/brickstrap
 [wiki]: https://github.com/ev3dev/ev3dev/wiki
+
+Rebasing
+--------
+
+```bash
+git remote add kernel https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+git fetch kernel tag v6.12.y
+git checkout bookworm
+git rebase v6.12.y
+```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ System Requirements
         sudo apt-get update
         # then install required packages
         sudo apt-get install git build-essential ncurses-dev fakeroot bc \
-        u-boot-tools lzop flex bison libssl-dev gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf -y
+        u-boot-tools lzop flex bison libssl-dev gcc-arm-linux-gnueabi
 
 
 Scripts
@@ -50,8 +50,8 @@ First time kernel build
     update the submodule commit in the kernel repo, so you have to pull manually
     to get the most recent commits).
 
-        ~/work $ git clone https://github.com/project516/ev3dev-buildscripts
-        ~/work $ git clone --recursive --depth 25 https://github.com/project516/ev3-kernel 
+        ~/work $ git clone https://github.com/ev3dev/ev3dev-buildscripts
+        ~/work $ git clone --recursive --depth 25 -b ev3dev-trixie https://github.com/ev3dev/ev3-kernel 
 
 3.  Change to the `ev3dev-buildscripts` directory and have a look around.
 
@@ -161,6 +161,12 @@ Sharing Your Kernel
 Want to send your custom kernel to someone so that they can use it? Never fear,
 there is an easy way to do that - using Debian packaging.
 
+Make sure to install debhelper with:
+
+```bash
+sudo apt-get install debhelper
+```
+
 First, we want to set a kernel option so that our friends will know what kernel
 they are running. Run `./menuconfig` and set this option:
 
@@ -230,8 +236,19 @@ Common Errors
 Rebasing
 --------
 
+If you want to update your kernel, rebase!
+
 ```bash
-git remote add kernel https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-git fetch kernel tag v6.12.y
+git remote add stable https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+git fetch stable tag v6.12.y # with 'y' being the latest version 
 git rebase v6.12.y
+```
+
+Updating Submodules
+-------------------
+
+If you want to update the submodules in the ev3-kernel (or you forgot to initialize them):
+
+```bash
+git submodule update --init --recursive --remote
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ These are the scripts used to compile the ev3dev kernel. Originally it also
 included scripts to bootstrap a root file system and create a disk image.
 Those scripts have evolved into the [brickstrap] package.
 
-**NOTE:** The instructions below are for ev3dev-buster. If you want to build
+**NOTE:** The instructions below are for ev3dev-trixie. If you want to build
 a kernel for ev3dev-stretch, please use the [ev3dev-stretch branch].
 
 [ev3dev-stretch branch]: https://github.com/ev3dev/ev3dev-buildscripts/tree/ev3dev-stretch
@@ -13,7 +13,7 @@ a kernel for ev3dev-stretch, please use the [ev3dev-stretch branch].
 System Requirements
 -------------------
 * Ubuntu LTS (can be run in a [virtual machine](https://www.virtualbox.org/)
-  or with [Windows Subsystem for Linux](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide))
+  or with [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/install))
 * User account with `sudo` enabled
 * Packages:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ System Requirements
         sudo apt-get update
         # then install required packages
         sudo apt-get install git build-essential ncurses-dev fakeroot bc \
-        u-boot-tools lzop flex bison libssl-dev gcc-arm-linux-gnueabi
+        u-boot-tools lzop flex bison libssl-dev gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf
 
 
 Scripts
@@ -51,7 +51,7 @@ First time kernel build
     to get the most recent commits).
 
         ~/work $ git clone https://github.com/project516/ev3dev-buildscripts
-        ~/work $ git clone --recursive --depth 25 https://github.com/project516/ev3-kernel
+        ~/work $ git clone --recursive --depth 25 https://github.com/project516/ev3-kernel 
 
 3.  Change to the `ev3dev-buildscripts` directory and have a look around.
 

--- a/build-kernel
+++ b/build-kernel
@@ -21,7 +21,7 @@ dtbs_install_path="$EV3DEV_INSTALL_DTBS"
 make_args="$EV3DEV_MAKE_ARGS -C ${kernel_src_path}
 	KBUILD_OUTPUT=${obj_path}
 	ARCH=arm
-	CROSS_COMPILE=$EV3DEV_TOOLCHAIN/$EV3DEV_ABI"
+	CROSS_COMPILE=${EV3DEV_TOOLCHAIN}${EV3DEV_ABI}"
 extra_default_targets="$EV3DEV_EXTRA_DEFAULT_TARGETS"
 uenv_txt_install_path="$EV3DEV_INSTALL_UENV_TXT"
 

--- a/defconfig
+++ b/defconfig
@@ -7,7 +7,7 @@
 kernel_src_path="$EV3DEV_KERNEL"
 obj_path="$EV3DEV_OBJ"
 make_args="$EV3DEV_MAKE_ARGS -C ${kernel_src_path} KBUILD_OUTPUT=${obj_path} \
-ARCH=arm CROSS_COMPILE=$EV3DEV_TOOLCHAIN/$EV3DEV_ABI"
+ARCH=arm CROSS_COMPILE=${EV3DEV_TOOLCHAIN}${EV3DEV_ABI}"
 
 show_usage ()
 {

--- a/setup-env
+++ b/setup-env
@@ -20,7 +20,7 @@
 # EV3DEV_INSTALL_MODULES: Where the kernel modules will be installed.
 # EV3DEV_INSTALL_DTBS: Where the device tree blocks will be installed.
 # EV3DEV_INSTALL_UENV_TXT: Where the uEnv.txt file is installed (BeagleBoard only).
-# EV3DEV_TOOLCHAIN: Where to find the cross-compiler toolchain.
+# EV3DEV_TOOLCHAIN: Where to find the cross-compiler toolchain (be sure to include trailing /).
 # EV3DEV_MERGE_CMD: The command that the defconfig script uses to merge files.
 #
 # Advanced/internal variables variables are:
@@ -53,8 +53,7 @@ fi
 export EV3DEV_KERNEL_FLAVOR=${EV3DEV_KERNEL_FLAVOR-"ev3"}
 export EV3DEV_BUILD_AREA=${EV3DEV_BUILD_AREA-"$(pwd)/build-area"}
 export EV3DEV_MERGE_CMD=${EV3DEV_MERGE_CMD-"vimdiff \$file1 \$file2"}
-export EV3DEV_TOOLCHAIN=${EV3DEV_TOOLCHAIN-"/usr/lib/x86_64-linux-gnu/gcc-linaro-arm-linux-gnueabihf-6.4/bin"}
-export EV3DEV_ABI=${EV3DEV_ABI-"arm-linux-gnueabihf-"}
+export EV3DEV_ABI=${EV3DEV_ABI-"arm-linux-gnueabi-"}
 
 if [ "$EV3DEV_KERNEL_FLAVOR" = "ev3" ]; then
     export EV3DEV_KERNEL=${EV3DEV_KERNEL-"$(pwd)/../ev3-kernel"}

--- a/setup-env
+++ b/setup-env
@@ -53,7 +53,7 @@ fi
 export EV3DEV_KERNEL_FLAVOR=${EV3DEV_KERNEL_FLAVOR-"ev3"}
 export EV3DEV_BUILD_AREA=${EV3DEV_BUILD_AREA-"$(pwd)/build-area"}
 export EV3DEV_MERGE_CMD=${EV3DEV_MERGE_CMD-"vimdiff \$file1 \$file2"}
-export EV3DEV_TOOLCHAIN=${EV3DEV_TOOLCHAIN-"/usr/lib/x86_64-linux-gnu/gcc-arm-linux-gnueabihf-8.3/bin"}
+export EV3DEV_TOOLCHAIN=${EV3DEV_TOOLCHAIN-"/usr/bin"}
 export EV3DEV_ABI=${EV3DEV_ABI-"arm-linux-gnueabihf-"}
 
 if [ "$EV3DEV_KERNEL_FLAVOR" = "ev3" ]; then

--- a/setup-env
+++ b/setup-env
@@ -55,7 +55,7 @@ export EV3DEV_BUILD_AREA=${EV3DEV_BUILD_AREA-"$(pwd)/build-area"}
 export EV3DEV_MERGE_CMD=${EV3DEV_MERGE_CMD-"vimdiff \$file1 \$file2"}
 
 export EV3DEV_TOOLCHAIN=${EV3DEV_TOOLCHAIN-"/usr/bin"}
-export EV3DEV_ABI=${EV3DEV_ABI-"arm-linux-gnueabihf-"}
+export EV3DEV_ABI=${EV3DEV_ABI-"/arm-linux-gnueabihf-"}
 
 
 if [ "$EV3DEV_KERNEL_FLAVOR" = "ev3" ]; then

--- a/setup-env
+++ b/setup-env
@@ -54,8 +54,8 @@ export EV3DEV_KERNEL_FLAVOR=${EV3DEV_KERNEL_FLAVOR-"ev3"}
 export EV3DEV_BUILD_AREA=${EV3DEV_BUILD_AREA-"$(pwd)/build-area"}
 export EV3DEV_MERGE_CMD=${EV3DEV_MERGE_CMD-"vimdiff \$file1 \$file2"}
 
-export EV3DEV_TOOLCHAIN=${EV3DEV_TOOLCHAIN-"/usr/bin"}
-export EV3DEV_ABI=${EV3DEV_ABI-"/arm-linux-gnueabihf-"}
+export EV3DEV_TOOLCHAIN=${EV3DEV_TOOLCHAIN-"/usr/bin/"}
+export EV3DEV_ABI=${EV3DEV_ABI-"arm-linux-gnueabi-"}
 
 
 if [ "$EV3DEV_KERNEL_FLAVOR" = "ev3" ]; then


### PR DESCRIPTION
This is the ev3dev-buildscripts repository I used to compile https://github.com/ev3dev/ev3-kernel/pull/17 and https://github.com/ev3dev/lego-linux-drivers/pull/86. There are a few minor changes in here.